### PR TITLE
pad r and s in signature to 32 bytes

### DIFF
--- a/lib/account.js
+++ b/lib/account.js
@@ -40,8 +40,8 @@ var fromPrivate = function fromPrivate(privateKey) {
 var encodeSignature = function encodeSignature(_ref) {
   var _ref2 = _slicedToArray(_ref, 3),
       v = _ref2[0],
-      r = _ref2[1],
-      s = _ref2[2];
+      r = Bytes.pad(32, _ref2[1]),
+      s = Bytes.pad(32, _ref2[2]);
 
   return Bytes.flatten([r, s, v]);
 };


### PR DESCRIPTION
When decoded from an RLP transaction, r and s may be provided as less than 32 bytes.

This fixes the failing test in https://github.com/ethereum/web3.js/pull/1290/