### PR TITLE
Pad tree nodes to even.

### DIFF
--- a/lib/rlp.js
+++ b/lib/rlp.js
@@ -23,7 +23,7 @@ var encode = function encode(tree) {
 
   var dataTree = function dataTree(tree) {
     if (typeof tree === "string") {
-      var hex = tree.slice(2);
+      var hex = padEven(tree.slice(2));
       var pre = hex.length != 2 || hex >= "80" ? length(hex.length / 2, 128) : "";
       return pre + hex;
     } else {


### PR DESCRIPTION
Fixes handling odd padded inputs, ie. `[..., '0x101', ...]` (rlp encoder). 