### PR TITLE
fix: remove 0x by regex in Account.fromPrivate

### DIFF
--- a/lib/account.js
+++ b/lib/account.js
@@ -20,7 +20,7 @@ const toChecksum = address => {
 };
 
 const fromPrivate = privateKey => {
-  const buffer = new Buffer(privateKey.slice(2), "hex");
+  const buffer = new Buffer(privateKey.replace(/^0x/, ""), "hex");
   const ecKey = secp256k1.keyFromPrivate(buffer);
   const publicKey = "0x" + ecKey.getPublic(false, 'hex').slice(2);
   const publicHash = keccak256(publicKey);

--- a/src/account.js
+++ b/src/account.js
@@ -23,7 +23,7 @@ const toChecksum = address => {
 }
 
 const fromPrivate = privateKey => {
-  const buffer = new Buffer(privateKey.slice(2), "hex");
+  const buffer = new Buffer(privateKey.replace(/^0x/, ""), "hex");
   const ecKey = secp256k1.keyFromPrivate(buffer);
   const publicKey = "0x" + ecKey.getPublic(false, 'hex').slice(2);
   const publicHash = keccak256(publicKey);

--- a/test/test.js
+++ b/test/test.js
@@ -52,6 +52,13 @@ describe("account", function () {
     }, 128);
   });
 
+  it("must generate the same public key", () => {
+    const prv = "0x4646464646464646464646464646464646464646464646464646464646464646";
+    const pk1 = Account.fromPrivate(prv);
+    const pk2 = Account.fromPrivate(prv.slice(2));
+    assert(pk1.address === pk2.address);
+  })
+
   it("must match expected values for complex pre-determined tests", () => {
     const accounts = [
       {


### PR DESCRIPTION
Account.fromPrivate will return different accounts when private key is passed with or without '0x'.
This PR removes '0x' from private key with regex in Account.fromPrivate.